### PR TITLE
- Fatal errors in unsupported browsers

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -11,6 +11,10 @@
 
 (function(window, $, undefined) {
 
+  if(!window.MutationObserver || typeof HTMLElement === 'undefined'){
+    return; //for unsupported browsers
+  }
+
   var utils = (function() {
     var matches = HTMLElement.prototype.matches || HTMLElement.prototype.webkitMatchesSelector || HTMLElement.prototype.mozMatchesSelector
                   || HTMLElement.prototype.msMatchesSelector;

--- a/src/arrive.js
+++ b/src/arrive.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /*
  * arrive.js
  * v2.0.0
@@ -10,6 +8,8 @@
  */
 
 (function(window, $, undefined) {
+
+  "use strict";
 
   if(!window.MutationObserver || typeof HTMLElement === 'undefined'){
     return; //for unsupported browsers


### PR DESCRIPTION
Script now wont throw fatal errors in unsupported browsers using feature detection. Can be included and used with progressive enhancement or graceful degradation.