### PR TITLE
Performance Optimisation

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -198,6 +198,9 @@
   function checkChildNodesRecursively(nodes, registrationData, callbacksToBeCalled) {
     // check each new node if it matches the selector
     for (var i=0, node; node = nodes[i]; i++) {
+        if ((' '+node.className+' ').indexOf(' ignoreArriveOrLeaveRecursively ') != -1) {
+            continue;
+        }
         if (utils.matchesSelector(node, registrationData.selector)) {
             // make sure the arrive event is not already fired for the element
             if (registrationData.firedElems.indexOf(node) == -1) {


### PR DESCRIPTION
Receiving huge chunks of HTML may cause arrive to make browser not responding for while. By adding ".ignore-arrive" class to any html entity, it and it's subtree will not fire any arrive event any more and as the result it can make a noticeable performance improvement.