### PR TITLE
'this' is not guaranteed to be bound to the window object

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -447,4 +447,4 @@ var Arrive = (function(window, $, undefined) {
 
   return Arrive;
 
-})(this, typeof jQuery === 'undefined' ? null : jQuery, undefined);
+})(window, typeof jQuery === 'undefined' ? null : jQuery, undefined);


### PR DESCRIPTION
Passing in 'this' into the top level closure in arrive.js assumes that it is bound to the browser 'window' object.

It is safer to pass in 'window' object directly because 'this' is not guaranteed to be bound to the window object when arrive.js is used in build tools like gulp, webpack, etc...