### PR TITLE
Make jshint/lint pass without change behavior

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -1,3 +1,7 @@
+/*globals jQuery,Window,HTMLElement,HTMLDocument,HTMLCollection,NodeList,MutationObserver */
+/*exported Arrive*/
+/*jshint latedef:false */
+
 /*
  * arrive.js
  * v2.3.1
@@ -6,7 +10,6 @@
  *
  * Copyright (c) 2014-2016 Uzair Farooq
  */
-
 var Arrive = (function(window, $, undefined) {
 
   "use strict";
@@ -24,26 +27,28 @@ var Arrive = (function(window, $, undefined) {
     return {
       matchesSelector: function(elem, selector) {
         return elem instanceof HTMLElement && matches.call(elem, selector);
-      }, 
+      },
       // to enable function overloading - By John Resig (MIT Licensed)
       addMethod: function (object, name, fn) {
         var old = object[ name ];
         object[ name ] = function(){
-          if ( fn.length == arguments.length )
+          if ( fn.length == arguments.length ) {
             return fn.apply( this, arguments );
-          else if ( typeof old == 'function' )
+          }
+          else if ( typeof old == 'function' ) {
             return old.apply( this, arguments );
+          }
         };
       },
       callCallbacks: function(callbacksToBeCalled) {
-        for (var i = 0, cb; cb = callbacksToBeCalled[i]; i++) {
+        for (var i = 0, cb; (cb = callbacksToBeCalled[i]); i++) {
           cb.callback.call(cb.elem, cb.elem);
         }
       },
       // traverse through all descendants of a node to check if event should be fired for any descendant
       checkChildNodesRecursively: function(nodes, registrationData, matchFunc, callbacksToBeCalled) {
         // check each new node if it matches the selector
-        for (var i=0, node; node = nodes[i]; i++) {
+        for (var i=0, node; (node = nodes[i]); i++) {
           if (matchFunc(node, registrationData, callbacksToBeCalled)) {
             callbacksToBeCalled.push({ callback: registrationData.callback, elem: node });
           }
@@ -58,10 +63,14 @@ var Arrive = (function(window, $, undefined) {
         var options = {},
             attrName;
         for (attrName in firstArr) {
-          options[attrName] = firstArr[attrName];
+          if (firstArr.hasOwnProperty(attrName)) {
+            options[attrName] = firstArr[attrName];
+          }
         }
         for (attrName in secondArr) {
-          options[attrName] = secondArr[attrName];
+          if (secondArr.hasOwnProperty(attrName)) {
+            options[attrName] = secondArr[attrName];
+          }
         }
         return options;
       },
@@ -91,23 +100,23 @@ var Arrive = (function(window, $, undefined) {
 
     EventsBucket.prototype.addEvent = function(target, selector, options, callback) {
       var newEvent = {
-        target:             target, 
-        selector:           selector, 
-        options:            options, 
-        callback:           callback, 
+        target:             target,
+        selector:           selector,
+        options:            options,
+        callback:           callback,
         firedElems:         []
       };
 
       if (this._beforeAdding) {
         this._beforeAdding(newEvent);
       }
-      
+
       this._eventsBucket.push(newEvent);
       return newEvent;
     };
 
     EventsBucket.prototype.removeEvent = function(compareFunction) {
-      for (var i=this._eventsBucket.length - 1, registeredEvent; registeredEvent = this._eventsBucket[i]; i--) {
+      for (var i=this._eventsBucket.length - 1, registeredEvent; (registeredEvent = this._eventsBucket[i]); i--) {
         if (compareFunction(registeredEvent)) {
           if (this._beforeRemoving) {
               this._beforeRemoving(registeredEvent);
@@ -134,7 +143,7 @@ var Arrive = (function(window, $, undefined) {
    * General class for binding/unbinding arrive and leave events
    */
   var MutationEvents = function(getObserverConfig, onMutation) {
-    var eventsBucket    = new EventsBucket(), 
+    var eventsBucket    = new EventsBucket(),
         me              = this;
 
     var defaultOptions = {
@@ -143,15 +152,14 @@ var Arrive = (function(window, $, undefined) {
 
     // actual event registration before adding it to bucket
     eventsBucket.beforeAdding(function(registrationData) {
-      var 
-        target    = registrationData.target, 
-        selector  = registrationData.selector, 
-        callback  = registrationData.callback, 
+      var
+        target    = registrationData.target,
         observer;
 
       // mutation observer does not work on window or document
-      if (target === window.document || target === window)
+      if (target === window.document || target === window) {
         target = document.getElementsByTagName("html")[0];
+      }
 
       // Create an observer instance
       observer = new MutationObserver(function(e) {
@@ -159,7 +167,7 @@ var Arrive = (function(window, $, undefined) {
       });
 
       var config = getObserverConfig(registrationData.options);
-      
+
       observer.observe(target, config);
 
       registrationData.observer = observer;
@@ -195,7 +203,7 @@ var Arrive = (function(window, $, undefined) {
 
     this.unbindEventWithSelectorOrCallback = function(selector) {
       var elements = utils.toElementsArray(this),
-          callback = selector, 
+          callback = selector,
           compareFunction;
 
       if (typeof selector === "function") {
@@ -242,9 +250,6 @@ var Arrive = (function(window, $, undefined) {
    * Processes 'arrive' events
    */
   var ArriveEvents = function() {
-    var mutationEvents,
-        me = this;
-
     // Default options for 'arrive' event
     var arriveDefaultOptions = {
       fireOnAttributesModification: false,
@@ -270,7 +275,8 @@ var Arrive = (function(window, $, undefined) {
       mutations.forEach(function( mutation ) {
         var newNodes    = mutation.addedNodes,
             targetNode = mutation.target,
-            callbacksToBeCalled = [];
+            callbacksToBeCalled = [],
+            node;
 
         // If new nodes are added
         if( newNodes !== null && newNodes.length > 0 ) {
@@ -358,13 +364,10 @@ var Arrive = (function(window, $, undefined) {
    * Processes 'leave' events
    */
   var LeaveEvents = function() {
-    var mutationEvents,
-        me = this;
-
     // Default options for 'leave' event
     var leaveDefaultOptions = {};
 
-    function getLeaveObserverConfig(options) {
+    function getLeaveObserverConfig() {
       var config = {
         childList: true,
         subtree: true
@@ -376,7 +379,6 @@ var Arrive = (function(window, $, undefined) {
     function onLeaveMutation(mutations, registrationData) {
       mutations.forEach(function( mutation ) {
         var removedNodes  = mutation.removedNodes,
-            targetNode   = mutation.target,
             callbacksToBeCalled = [];
 
         if( removedNodes !== null && removedNodes.length > 0 ) {


### PR DESCRIPTION
JSHint is a tool to check your JS code for common coding-mistakes or bad practices - after trying to pass the lib over a CI server, I've found some Notices/Warnings and Errors.

This PR fix that with minimum code changeset.

Before the changes, JSHint found 35 potentially mistakes, now are 0.