### PR TITLE
Fixes #82 - Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ As of v2.0 `arrive` event accepts an optional `options` object as 2nd argument. 
 ```javascript
 var options = {
     fireOnAttributesModification: boolean, // Defaults to false. Setting it to true would make arrive event fire on existing elements which start to satisfy selector after some modification in DOM attributes (an arrive event won't fire twice for a single element even if the option is true). If false, it'd only fire for newly created elements.
-    onceOnly: boolean                      // Defaults to false. Setting it to true would ensure that registered callbacks fire only once. No need to unbind the event if the attribute is set to true, it'll automatically unbind after firing once.
-    existing: boolean                      // Defaults to false. Setting it to true would ensure that the registered callback is fired for the elements that already exist in the DOM and match the selector. If options.onceOnly is set, the callback is only called once with the first element matching the selector.
+    onceOnly: boolean,                     // Defaults to false. Setting it to true would ensure that registered callbacks fire only once. No need to unbind the event if the attribute is set to true, it'll automatically unbind after firing once.
+    existing: boolean,                     // Defaults to false. Setting it to true would ensure that the registered callback is fired for the elements that already exist in the DOM and match the selector. If options.onceOnly is set, the callback is only called once with the first element matching the selector.
+    timeout: number                        // Defaults to 0 (no timeout). Setting a positive number will call the callback with null after the specified number of milliseconds. Event is automatically unbinded when timeout is reached.
 };
 ```
 Example:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var options = {
 ```
 Example:
 ```javascript
-document.arrive(".test-elem", {fireOnAttributesModification: true}, function(newElem) {
+document.arrive(".test-elem", { fireOnAttributesModification: true}, function(newElem) {
     // 'newElem' refers to the newly created element
 });
 ```

--- a/src/arrive.js
+++ b/src/arrive.js
@@ -40,7 +40,7 @@ var Arrive = (function(window, $, undefined) {
           }
         };
       },
-      callCallbacks: function(callbacksToBeCalled, registrationData) {
+      callCallbacks: function(callbacksToBeCalled, registrationData, mutationEvents) {
         if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length == 1) {
           // as onlyOnce param is true, make sure we fire the event for only one item
           callbacksToBeCalled = [callbacksToBeCalled[0]];
@@ -50,6 +50,10 @@ var Arrive = (function(window, $, undefined) {
           if (cb && cb.callback) {
             cb.callback.call(cb.elem, cb.elem);
           }
+        }
+
+        if (registrationData && mutationEvents) {
+          mutationEvents.addTimeoutHandler(registrationData.target, registrationData.selector, registrationData.callback, registrationData.options, registrationData.data);
         }
 
         if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length == 1) {
@@ -111,12 +115,13 @@ var Arrive = (function(window, $, undefined) {
       this._beforeRemoving  = null;
     };
 
-    EventsBucket.prototype.addEvent = function(target, selector, options, callback) {
+    EventsBucket.prototype.addEvent = function(target, selector, options, callback, data) {
       var newEvent = {
         target:             target,
         selector:           selector,
         options:            options,
         callback:           callback,
+        data:               data,
         firedElems:         []
       };
 
@@ -133,6 +138,10 @@ var Arrive = (function(window, $, undefined) {
         if (compareFunction(registeredEvent)) {
           if (this._beforeRemoving) {
               this._beforeRemoving(registeredEvent);
+          }
+
+          if (registeredEvent.data && registeredEvent.data.timeoutId) {
+            clearTimeout(registeredEvent.data.timeoutId);
           }
 
           // mark callback as null so that even if an event mutation was already triggered it does not call callback
@@ -203,7 +212,12 @@ var Arrive = (function(window, $, undefined) {
       var elements = utils.toElementsArray(this);
 
       for (var i = 0; i < elements.length; i++) {
-        eventsBucket.addEvent(elements[i], selector, options, callback);
+        const data = {};
+
+      // Add timeout handling
+        me.addTimeoutHandler(elements[i], selector, callback, options, data);
+
+        eventsBucket.addEvent(elements[i], selector, options, callback, data);
       }
     };
 
@@ -259,6 +273,21 @@ var Arrive = (function(window, $, undefined) {
       });
     };
 
+    this.addTimeoutHandler = function(target, selector, callback, options, data) {
+      if (!options.timeout || options.timeout <= 0) {
+        return;
+      }
+    
+      if (data.timeoutId) {
+        clearTimeout(data.timeoutId);
+      }
+    
+      data.timeoutId = setTimeout(() => {
+        me.unbindEventWithSelectorAndCallback.call(target, selector, callback);
+        callback.call(null, null);
+      }, options.timeout);
+    }
+
     return this;
   };
 
@@ -272,7 +301,8 @@ var Arrive = (function(window, $, undefined) {
     var arriveDefaultOptions = {
       fireOnAttributesModification: false,
       onceOnly: false,
-      existing: false
+      existing: false,
+      timeout: 0  // default 0 (no timeout)
     };
 
     function getArriveObserverConfig(options) {
@@ -306,7 +336,7 @@ var Arrive = (function(window, $, undefined) {
           }
         }
 
-        utils.callCallbacks(callbacksToBeCalled, registrationData);
+        utils.callCallbacks(callbacksToBeCalled, registrationData, arriveEvents);
       });
     }
 
@@ -394,7 +424,7 @@ var Arrive = (function(window, $, undefined) {
           utils.checkChildNodesRecursively(removedNodes, registrationData, nodeMatchFunc, callbacksToBeCalled);
         }
 
-        utils.callCallbacks(callbacksToBeCalled, registrationData);
+        utils.callCallbacks(callbacksToBeCalled, registrationData, leaveEvents);
       });
     }
 
@@ -421,6 +451,7 @@ var Arrive = (function(window, $, undefined) {
 
     return leaveEvents;
   };
+
 
 
   var arriveEvents = new ArriveEvents(),

--- a/src/arrive.js
+++ b/src/arrive.js
@@ -52,7 +52,7 @@ var Arrive = (function(window, $, undefined) {
           }
         }
 
-        if (registrationData && mutationEvents) {
+        if (registrationData && registrationData.callback && mutationEvents) {
           mutationEvents.addTimeoutHandler(registrationData.target, registrationData.selector, registrationData.callback, registrationData.options, registrationData.data);
         }
 

--- a/src/arrive.js
+++ b/src/arrive.js
@@ -404,7 +404,9 @@ var Arrive = (function(window, $, undefined) {
    */
   var LeaveEvents = function() {
     // Default options for 'leave' event
-    var leaveDefaultOptions = {};
+    var leaveDefaultOptions = {
+      timeout: 0  // default 0 (no timeout)
+    };
 
     function getLeaveObserverConfig() {
       var config = {

--- a/tests/spec/arriveSpec.js
+++ b/tests/spec/arriveSpec.js
@@ -321,6 +321,27 @@ describe("Arrive", function() {
                     done();
                 }, 500);
             });
+
+            it("should automatically unbind arrive event after timeout", function(done) {
+                var selector = ".test-timeout-5";
+                var callCount = 0;
+                
+                j(document).arrive(selector, { timeout: 200 }, function(elem) {
+                    callCount++;
+                });
+
+                // Wait for timeout to pass
+                setTimeout(function() {
+                    // Add element after timeout
+                    $("body").append($("<div class='test-timeout-5'></div>"));
+                    
+                    // Check after a delay that callback wasn't called
+                    setTimeout(function() {
+                        expect(callCount).toBe(1); // Should only be called once with null
+                        done();
+                    }, 200);
+                }, 300);
+            });
         });
 
         describe("options.existing", function() {


### PR DESCRIPTION
This PR adds a new timeout option to both arrive and leave events that automatically unbinds the event and calls the callback with null after the specified number of milliseconds if no matching elements are found/removed.

This is useful for cases where you want to stop watching for elements after a certain time period.

### Usage
```javascript
// Will call callback with null after 2 seconds if no matching element is found
document.arrive(".dynamic-content", { timeout: 2000 }, function(elem) {
    if (elem === null) {
        console.log("Element not found within timeout");
        return;
    }
    console.log("Element found:", elem);
});
```

### Related Issues
Closes #82 