### PR TITLE
Add onceOnly option for leave events

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -41,9 +41,14 @@ var Arrive = (function(window, $, undefined) {
         };
       },
       callCallbacks: function(callbacksToBeCalled, registrationData, mutationEvents) {
-        if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length == 1) {
+        // firedElems check because firedElems are not added in case of leave events
+        if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length <= 1) {
           // as onlyOnce param is true, make sure we fire the event for only one item
           callbacksToBeCalled = [callbacksToBeCalled[0]];
+
+          // unbind event after first callback as onceOnly is true.
+          registrationData.me.unbindEventWithSelectorAndCallback.call(
+            registrationData.target, registrationData.selector, registrationData.callback);
         }
 
         for (var i = 0, cb; (cb = callbacksToBeCalled[i]); i++) {
@@ -54,12 +59,6 @@ var Arrive = (function(window, $, undefined) {
 
         if (registrationData && registrationData.callback && mutationEvents) {
           mutationEvents.addTimeoutHandler(registrationData.target, registrationData.selector, registrationData.callback, registrationData.options, registrationData.data);
-        }
-
-        if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length == 1) {
-          // unbind event after first callback as onceOnly is true.
-          registrationData.me.unbindEventWithSelectorAndCallback.call(
-            registrationData.target, registrationData.selector, registrationData.callback);
         }
       },
       // traverse through all descendants of a node to check if event should be fired for any descendant
@@ -405,7 +404,8 @@ var Arrive = (function(window, $, undefined) {
   var LeaveEvents = function() {
     // Default options for 'leave' event
     var leaveDefaultOptions = {
-      timeout: 0  // default 0 (no timeout)
+      onceOnly: false,
+      timeout: 0,  // default 0 (no timeout)
     };
 
     function getLeaveObserverConfig() {
@@ -492,3 +492,4 @@ var Arrive = (function(window, $, undefined) {
   return Arrive;
 
 })(window, typeof jQuery === 'undefined' ? null : jQuery, undefined);
+

--- a/tests/spec/arriveSpec.js
+++ b/tests/spec/arriveSpec.js
@@ -472,6 +472,48 @@ describe("Arrive", function() {
                 }, 100);
             });
         });
+
+        describe("Multiple leave events tests", function() {
+            var selector = ".test-leave-multiple";
+
+            beforeEach(function() {
+                Arrive.unbindAllLeave();
+                $(selector).remove();
+            });
+
+            it("Callback should be called multiple times when multiple elements are removed", function(done) {
+                var callCount = 0;
+                var $elements = $("<div class='test-leave-multiple'></div><div class='test-leave-multiple'></div>");
+                $("body").append($elements);
+
+                j(document).leave(selector, function() {
+                    callCount += 1;
+                    if (callCount >= 2) {
+                        expect(callCount).toBe(2);
+                        done();
+                    }
+                });
+
+                $(selector).remove();
+            });
+
+            it("onceOnly option should result in callback being called only once", function(done) {
+                var callCount = 0;
+                var $elements = $("<div class='test-leave-multiple'></div><div class='test-leave-multiple'></div>");
+                $("body").append($elements);
+
+                j(document).leave(selector, { onceOnly: true }, function() {
+                    callCount += 1;
+                });
+
+                $(selector).remove();
+
+                setTimeout(function() {
+                    expect(callCount).toBe(1);
+                    done();
+                }, 400);
+            });
+        });
     });
 
     describe("ES2015 arrow function support", function() {


### PR DESCRIPTION
# Add onceOnly option support for leave events

## Description
This PR adds support for the `onceOnly` option to leave events, making the behavior consistent with arrive events. The `onceOnly` option allows the leave callback to be executed only once before automatically unbinding the event.

## Changes
- Added `onceOnly` option to leave events default options
- Leave events now respect the `onceOnly` setting similar to arrive events
- Default value is `false` to maintain backward compatibility

## Example Usage