### PR TITLE
Fixes for leave promise events

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -455,6 +455,9 @@ var Arrive = (function(window, $, undefined) {
       if (callback) {
         mutationBindEvent.call(this, selector, options, callback);
       } else {
+        // For promise and async support, we can only do onceOnly=true
+        options.onceOnly = true;
+
         var a = this;
         return new Promise(resolve => mutationBindEvent.call(a, selector, options, resolve));
       }

--- a/src/arrive.js
+++ b/src/arrive.js
@@ -363,7 +363,7 @@ var Arrive = (function(window, $, undefined) {
     // override bindEvent function
     arriveEvents.bindEvent = function(selector, arg2, arg3) {
 
-      var options = (typeof arg2 === 'object') ? utils.mergeArrays(arriveDefaultOptions, arg2) : arriveDefaultOptions;
+      var options = (typeof arg2 === 'object') ? utils.mergeArrays(arriveDefaultOptions, arg2) : { ...arriveDefaultOptions };
       var callback = (typeof arg3 === 'function') ? arg3 : (typeof arg2 === 'function') ? arg2 : undefined;
       var elements = utils.toElementsArray(this);
 
@@ -449,7 +449,7 @@ var Arrive = (function(window, $, undefined) {
     // override bindEvent function
     leaveEvents.bindEvent = function(selector, arg2, arg3) {
 
-      var options = (typeof arg2 === 'object') ? utils.mergeArrays(leaveDefaultOptions, arg2) : leaveDefaultOptions;
+      var options = (typeof arg2 === 'object') ? utils.mergeArrays(leaveDefaultOptions, arg2) : { ...leaveDefaultOptions };
       var callback = (typeof arg3 === 'function') ? arg3 : (typeof arg2 === 'function') ? arg2 : undefined;
 
       if (callback) {


### PR DESCRIPTION
- Fix: Set onceOnly to true for promise based calls
- Bug Fix: Always copy default options to preserve the originals