### PR TITLE
Bug fix: Arrive event with onceOnly not triggered in some cases

### DIFF
--- a/src/arrive.js
+++ b/src/arrive.js
@@ -41,8 +41,9 @@ var Arrive = (function(window, $, undefined) {
         };
       },
       callCallbacks: function(callbacksToBeCalled, registrationData, mutationEvents) {
-        // firedElems check because firedElems are not added in case of leave events
-        if (registrationData && registrationData.options.onceOnly && registrationData.firedElems.length <= 1) {
+        if (!callbacksToBeCalled.length) return;
+
+        if (registrationData && registrationData.options.onceOnly) {
           // as onlyOnce param is true, make sure we fire the event for only one item
           callbacksToBeCalled = [callbacksToBeCalled[0]];
 


### PR DESCRIPTION
If an event is registered with the `onceOnly` option, it prematurely unregisters the event on mutation events, even when the actual element is not injected.